### PR TITLE
Add two days

### DIFF
--- a/src/periods/christmas.js
+++ b/src/periods/christmas.js
@@ -3,6 +3,8 @@ import makePayload from '../utils/makePayload.js'
 
 const getDays = startYear => {
   const christmasEve = getChristmasEve(startYear)
+  const christmasDay = christmasEve.plus({ days: 1 })
+
   const payload = [
     {
       name: 'Julaften',
@@ -13,7 +15,7 @@ const getDays = startYear => {
     },
     {
       name: 'Juledag',
-      date: christmasEve.plus({ days: 1 }),
+      date: christmasDay,
       color: 'white',
       id: '2-christmas',
     },
@@ -23,6 +25,12 @@ const getDays = startYear => {
       date: christmasEve.plus({ day: 2 }),
       color: 'red',
       id: '3-christmas',
+    },
+    {
+      name: 'Romjulssøndag',
+      date: christmasDay.plus({ days: (7 - christmasDay.weekday) % 7 }),
+      color: 'white',
+      id: 'christmas-sunday',
     },
     {
       name: 'Nyttårsaften',

--- a/src/readings/prayersList.js
+++ b/src/readings/prayersList.js
@@ -85,7 +85,7 @@ som med deg og Den hellige ånd lever og råder,
 én sann Gud fra evighet til evighet.
 Amen.`
 
-  this['RomjulsSøndag'] = `
+  this['Romjulssøndag'] = `
 Nådige Gud,
 du lot din Sønn bli et sårbart menneske.
 Vi ber deg:

--- a/src/readings/readingsList.js
+++ b/src/readings/readingsList.js
@@ -123,6 +123,26 @@ const readingsList = new function() {
     ],
   }
 
+  this['Romjulssøndag'] = {
+    I: [
+      'Sal 1,1-6',
+      '1 Tim 3,16',
+      'Matt 2,13-15',
+    ],
+    II: [
+      '2 Mos 1,15-21',
+      'Apg 7,17-22',
+      'Luk 2,36-38',
+    ],
+    III: [
+      'Jes 66,10-13',
+      'Rom 11,33-36',
+      'Luk 2,25-35',
+    ],
+    F: [
+      'Luk 2,22-40',    ],
+  }
+
   this['Nyttårsaften'] = {
     I: [
       'Fork 3,1-2.4-7.11a',

--- a/src/readings/readingsList.js
+++ b/src/readings/readingsList.js
@@ -1342,6 +1342,9 @@ const readingsList = new function() {
   this['26. Søndag i Treenighetstiden'] = {
     ...this['4. Søndag i Åpenbaringstiden'],
   }
+  this['27. Søndag i Treenighetstiden'] = {
+    ...this['3. Søndag i Åpenbaringstiden'],
+  }
   this['Kristi kongedag'] = {
     I: [
       'Jes 57,14-16',


### PR DESCRIPTION
For a complete list of readings, this PR adds two missing days to the reading list:
"Romjulssøndag" and "27. Søndag i Treenighetstiden".

Thanks! 