### PR TITLE
Fix reference in Stefanusdag readings

### DIFF
--- a/readings/Stefanusdag
+++ b/readings/Stefanusdag
@@ -1,5 +1,5 @@
 Stefanusdag | 2. juledag
-I	Jer 31,15–17
+I	Jer 31,5–17
  	Apg 7,52–60
  	Matt 2,16–23
 II	Sal 86,11–17


### PR DESCRIPTION
Fix typo in readings list for "2. Juledag" by correcting the verse reference from Jer 31,5-17 to Jer 31,15-17.