### PR TITLE
Fix scripture reference for 2. Juledag

### DIFF
--- a/src/readings/readingsList.js
+++ b/src/readings/readingsList.js
@@ -104,7 +104,7 @@ const readingsList = new function() {
 
   this['2. Juledag'] = {
     I: [
-      'Jer 31,5-17',
+      'Jer 31,15-17',
       'Apg 7,52-60',
       'Matt 2,16-23',
     ],


### PR DESCRIPTION
Fix typo in readings list for "2. Juledag" by correcting the verse reference from Jer 31,5-17 to Jer 31,15-17.